### PR TITLE
perldoc shows example config without newlines

### DIFF
--- a/check.autoincrement
+++ b/check.autoincrement
@@ -143,7 +143,7 @@ check.autoincrement -- Check if mysql auto_increment columns are close to reachi
 
 =head1 SYNOPSIS
 
-check.autoincrement --configfile=check-ai.conf
+    check.autoincrement --configfile=check-ai.conf
 
 Where check-ai.conf has the following format:
 

--- a/check.autoincrement
+++ b/check.autoincrement
@@ -146,13 +146,13 @@ check.autoincrement -- Check if mysql auto_increment columns are close to reachi
 check.autoincrement --configfile=check-ai.conf
 
 Where check-ai.conf has the following format:
-
-dbhost=hostname
-dbuser=root
-dbpass=verysecret
-critical=0.85
-warning=0.7
-verbosity=0
+E<10> E<8>
+dbhost=hostnameE<10> E<8>
+dbuser=rootE<10> E<8>
+dbpass=verysecretE<10> E<8>
+critical=0.85E<10> E<8>
+warning=0.7E<10> E<8>
+verbosity=0E<10> E<8>
 
 =head1 DESCRIPTION
 

--- a/check.autoincrement
+++ b/check.autoincrement
@@ -146,13 +146,13 @@ check.autoincrement -- Check if mysql auto_increment columns are close to reachi
 check.autoincrement --configfile=check-ai.conf
 
 Where check-ai.conf has the following format:
-E<10> E<8>
-dbhost=hostnameE<10> E<8>
-dbuser=rootE<10> E<8>
-dbpass=verysecretE<10> E<8>
-critical=0.85E<10> E<8>
-warning=0.7E<10> E<8>
-verbosity=0E<10> E<8>
+
+    dbhost=hostname
+    dbuser=root
+    dbpass=verysecret
+    critical=0.85
+    warning=0.7
+    verbosity=0
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
I've added some hard newlines to the config (E<10> E<8>) because I had issues with the configuration file because pearldoc showed everything in one line